### PR TITLE
Use Nix crate instead of libc to implement `now()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ keywords = ["date", "time", "monotonic", "tai", "gps"]
 [dependencies]
 chrono = { version = "0.4.31", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
-libc = { version = "0.2.68", default-features = false, optional = true }
+nix = { version = "0.26", default-features = false, features = ["time"], optional = true }
 
 [features]
 default = ["std"]
@@ -30,7 +30,7 @@ std = []
 # activated since cargo resolver v2 ignores MSRV.
 chrono = ["dep:chrono"]
 serde = ["dep:serde"]
-tai_clock = ["dep:libc"]
+tai_clock = ["dep:nix"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Closes #15.